### PR TITLE
EBT: Batch messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 dist-newstyle
 Setup.hs
 .ghc.environment.*
+tags

--- a/test/Network/Gossip/Test/Broadcast.hs
+++ b/test/Network/Gossip/Test/Broadcast.hs
@@ -160,11 +160,11 @@ runBroadcast network node ma = runPlumtree (nodeEnv node) ma >>= eval
             onNode network to $ receive msg
             k >>= eval
 
-        SendLazy to ihave k -> do
+        SendLazy to ihaves k -> do
             task <-
                 async $ do
                     threadDelay 30000
-                    onNode network to $ receive (IHaveM ihave)
+                    onNode network to $ receive (IHaveM ihaves)
             atomically $ writeTQueue (netScheduler network) task
             k >>= eval
 


### PR DESCRIPTION
This is an obvious optimisation: we're buffering `IHave`s, thus may put them on
the wire as one message. Correspondingly, we can construct a batch of `Graft`s
from that. Obviously, the reply to `Graft` can now batch all payload messages
together.

A future changeset should introduce a (configurable) limit on the batch sizes.

Fixes #9