### PR TITLE
Lift the requirement of pre-shared keys of seed nodes

### DIFF
--- a/gossip.cabal
+++ b/gossip.cabal
@@ -105,8 +105,10 @@ test-suite tests
     build-depends:
         algebraic-graphs == 0.2.*
       , gossip
+      , hashable
       , hedgehog
       , hedgehog-quickcheck
+      , microlens
       , QuickCheck
       , random
 

--- a/src/Network/Gossip/HyParView/Periodic.hs
+++ b/src/Network/Gossip/HyParView/Periodic.hs
@@ -38,7 +38,7 @@ defaultConfig = Config
 
 newtype Periodic = Periodic (Async ())
 
-new :: (Eq n, Hashable n)
+new :: (Eq n, Hashable n, H.HasPeer n)
     => Config
     -> (H.HyParView n () -> IO ())
     -> IO Periodic
@@ -53,11 +53,11 @@ destroy :: Periodic -> IO ()
 destroy (Periodic t) = uninterruptibleCancel t
 
 withPeriodic
-    :: (Eq n, Hashable n)
+    :: (Eq n, Hashable n, H.HasPeer n)
     => Config
     -> (H.HyParView n () -> IO ())
-    -> (Periodic -> IO a)
-    -> IO a
+    -> (Periodic -> IO b)
+    -> IO b
 withPeriodic cfg run = bracket (new cfg run) destroy
 
 --------------------------------------------------------------------------------

--- a/src/Network/Gossip/IO/Trace.hs
+++ b/src/Network/Gossip/IO/Trace.hs
@@ -30,16 +30,19 @@ data Traceable n
     | TraceWire       (WireEvent       n)
 
 data BootstrapEvent n where
-    Bootstrapping :: Traversable t => Peer n -> t (Peer n) -> BootstrapEvent n
+    Bootstrapping :: Traversable t
+                  => Peer n
+                  -> t (Maybe n, SockAddr)
+                  -> BootstrapEvent n
     Bootstrapped  :: Peer n -> BootstrapEvent n
 
 data ConnectionEvent n
-    = Connecting         (Peer n)
-    -- ^ Connecting to 'Peer'
+    = Connecting         SockAddr (Maybe n)
+    -- ^ Connecting to peer at 'SockAddr', optionally identified by 'n'
     | Connected          (Peer n)
     -- ^ Outgoing connection to 'Peer' established
-    | ConnectFailed      (Peer n) SomeException
-    -- ^ Outgoing connection attempt to 'Peer' failed with 'SomeException'
+    | ConnectFailed      SockAddr (Maybe n) SomeException
+    -- ^ Outgoing connection attempt to peer failed with 'SomeException'
     | ConnectionLost     (Peer n) SomeException
     -- ^ Connection reset by 'Peer'
     | ConnectionAccepted SockAddr


### PR DESCRIPTION
Essentially, the membership protocol now knows that a peer is the tuple `(node id, network address)`, which the handshake protocol is obliged to return us (or an error if it doesn't support establishing a channel without a PSK, and none is provided). 