### PR TITLE
Export join* from IO.Run

### DIFF
--- a/gossip.cabal
+++ b/gossip.cabal
@@ -106,8 +106,8 @@ test-suite tests
         algebraic-graphs == 0.2.*
       , gossip
       , hashable
-      , hedgehog
-      , hedgehog-quickcheck
+      , hedgehog >= 0.6
+      , hedgehog-quickcheck >= 0.1.1
       , microlens
       , QuickCheck
       , random

--- a/src/Network/Gossip/IO/Run.hs
+++ b/src/Network/Gossip/IO/Run.hs
@@ -14,6 +14,8 @@ module Network.Gossip.IO.Run
     , broadcast
     , getPeers
     , getPeers'
+    , joinAny
+    , joinFirst
     )
 where
 
@@ -127,6 +129,12 @@ getPeers env = runHyParView env H.getPeers
 
 getPeers' :: (Eq n, Hashable n) => Env n -> IO (H.Peers (Peer n))
 getPeers' env = runHyParView env H.getPeers'
+
+joinAny :: (Eq n, Hashable n) => Env n -> [(Maybe n, Network.SockAddr)] -> IO ()
+joinAny env = runHyParView env . H.joinAny
+
+joinFirst :: (Eq n, Hashable n) => Env n -> [(Maybe n, Network.SockAddr)] -> IO ()
+joinFirst env = runHyParView env . H.joinFirst
 
 evalPlumtree
     :: (Eq n, Hashable n)


### PR DESCRIPTION
To allow for late joining, e.g. after a partition, or if no peers found
during startup.